### PR TITLE
Pad video for H264

### DIFF
--- a/betatv.py
+++ b/betatv.py
@@ -153,6 +153,7 @@ for root,d_names,f_names in os.walk(betaconst.video_path_uncensored):
                                 '-c:v', 'libx264',
                                 '-crf', '23',
                                 '-preset', 'veryfast',
+                                '-vf', 'pad=ceil(iw/2)*2:ceil(ih/2)*2',
                                 '-map', '0:0',
                                 '-map', '1:a',
                                 '-shortest',
@@ -168,6 +169,7 @@ for root,d_names,f_names in os.walk(betaconst.video_path_uncensored):
                                 '-c:v', 'libx264',
                                 '-crf', '23',
                                 '-preset', 'veryfast',
+                                '-vf', 'pad=ceil(iw/2)*2:ceil(ih/2)*2',
                                 censored_path
                         ]
 


### PR DESCRIPTION
Ensure that re-encoded dimensions are multiple of 2, libx264 requires this.

https://stackoverflow.com/questions/20847674/ffmpeg-libx264-height-not-divisible-by-2